### PR TITLE
Migrate deprecated set-output to GITHUB_OUTPUT env

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,4 +14,4 @@ PARENT=$(skopeo inspect docker://"$2" | jq .Layers)
 OUTOFDATE=$(jq -cn "$OWN - ($OWN - $PARENT) | .==[]")
 
 # Return the result.
-echo "::set-output name=out-of-date::$OUTOFDATE"
+echo "out-of-date=$OUTOFDATE" >> $GITHUB_OUTPUT


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/